### PR TITLE
Docker updates

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -1,7 +1,19 @@
 ---
-- name: Docker | Install Docker 1.9+
+- name: Docker | Prerequisites
   sudo: yes
   shell: "{{item}}"
   with_items:
-    - "curl -sSL https://get.docker.com/ | sh"
-    - "usermod -a -G docker $USER"
+    - "apt-get update"
+    - "apt-get install -y apt-transport-https"
+
+- name: Docker | Add repo to APT sources
+  sudo: yes
+  shell: "echo deb https://apt.dockerproject.org/repo ubuntu-trusty main > /etc/apt/sources.list.d/docker.list"
+
+- name: Docker | Import the repo key
+  sudo: yes
+  shell: "apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D"
+
+- name: Docker | Install Docker 1.9.0
+  sudo: yes
+  shell: "apt-get install -y docker-engine=1.9.0-0~trusty"

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -16,4 +16,7 @@
 
 - name: Docker | Install Docker 1.9.0
   sudo: yes
-  shell: "apt-get install -y docker-engine=1.9.0-0~trusty"
+  shell: "{{item}}"
+  with_items:
+    - "apt-get update"
+    - "apt-get install -y docker-engine=1.9.0-0~trusty"


### PR DESCRIPTION
This removes the curl | sh command and replaces it with an exact download of version 1.9.0 for Ubuntu 14.04.