### PR TITLE
Update wine install commands

### DIFF
--- a/roles/wine/tasks/main.yml
+++ b/roles/wine/tasks/main.yml
@@ -4,6 +4,8 @@
   sudo: yes
   with_items:
     - "dpkg --add-architecture i386"
-    - "add-apt-repository ppa:ubuntu-wine/ppa"
+    - "wget -nc https://dl.winehq.org/wine-builds/Release.key"
+    - "apt-key add Release.key"
+    - "apt-add-repository https://dl.winehq.org/wine-builds/ubuntu/"
     - "apt-get update"
-    - "apt-get install -y wine1.7"
+    - "apt-get install -y winehq-stable"


### PR DESCRIPTION
Old method seems to break `vagrant up` for snowplow/sql-runner.