### PR TITLE
Add Java 10 and remove old unsupported versions

### DIFF
--- a/java10.yml
+++ b/java10.yml
@@ -2,4 +2,4 @@
 - hosts: vagrant
   remote_user: vagrant
   roles:
-    - { role: oracle-java, oracle_java_version: 7 }
+    - { role: oracle-java, oracle_java_version: 10 }

--- a/java6.yml
+++ b/java6.yml
@@ -1,5 +1,0 @@
----
-- hosts: vagrant
-  remote_user: vagrant
-  roles:
-    - { role: oracle-java, oracle_java_version: 6 }

--- a/java8.yml
+++ b/java8.yml
@@ -2,4 +2,4 @@
 - hosts: vagrant
   remote_user: vagrant
   roles:
-    - { role: oracle-java } # Note: oracle-java v8 installed by default (no need to specify)
+    - { role: oracle-java, oracle_java_version: 8} # Note: oracle-java v8 installed by default (no need to specify)

--- a/roles/elasticsearch/meta/main.yml
+++ b/roles/elasticsearch/meta/main.yml
@@ -1,3 +1,3 @@
 ---
 dependencies:
-  - { role: oracle-java, oracle_java_version: 7 }
+  - { role: oracle-java, oracle_java_version: 8 }

--- a/roles/oracle-java/tasks/main.yml
+++ b/roles/oracle-java/tasks/main.yml
@@ -7,25 +7,26 @@
     - ant
     - maven
 
-- name: Install Oracle Java Repo Installer Repository
+- name: Install Oracle Java 8 Repo Installer Repository
   apt_repository: repo=ppa:webupd8team/java update-cache=yes 
+  when: oracle_java_version == 8
+  sudo: yes
+
+- name: Install Oracle Java 10 Repo Installer Repository
+  apt_repository: repo=ppa:linuxuprising/java
+  when: oracle_java_version == 10
   sudo: yes
 
 - name: Wizardry to bypass the Oracle License File prompt
   shell: echo debconf shared/accepted-oracle-license-v1-1 select true | debconf-set-selections
   sudo: yes
 
-- name: Install Oracle Java 6
-  apt: pkg=oracle-java6-installer
-  when: oracle_java_version == 6
-  sudo: yes
-
-- name: Install Oracle Java 7
-  apt: pkg=oracle-java7-installer
-  when: oracle_java_version == 7
-  sudo: yes
-
 - name: Install Oracle Java 8
   apt: pkg=oracle-java8-installer
   when: oracle_java_version == 8
+  sudo: yes
+
+- name: Install Oracle Java 10
+  apt: pkg=oracle-java10-installer
+  when: oracle_java_version == 10
   sudo: yes

--- a/snowplow-batch-pipeline.yml
+++ b/snowplow-batch-pipeline.yml
@@ -2,7 +2,8 @@
 - hosts: vagrant
   remote_user: vagrant
   roles:
-    - { role: scala, oracle_java_version: 8 }
+    - { role: oracle-java, oracle_java_version: 8 }
+    - scala
     - gradle
     - sbt
     - ruby-rvm

--- a/snowplow-batch-pipeline.yml
+++ b/snowplow-batch-pipeline.yml
@@ -2,7 +2,7 @@
 - hosts: vagrant
   remote_user: vagrant
   roles:
-    - { role: scala, oracle_java_version: 6 }
+    - { role: scala, oracle_java_version: 8 }
     - gradle
     - sbt
     - ruby-rvm

--- a/spark.yml
+++ b/spark.yml
@@ -2,5 +2,5 @@
 - hosts: vagrant
   remote_user: vagrant
   roles:
-    - { role: oracle-java, oracle_java_version: 7 }
+    - { role: oracle-java, oracle_java_version: 8 }
     - spark


### PR DESCRIPTION
Java 9 is end-of-life, and Oracle made all older versions inaccessible. This should fix any playbooks that pull in Java.

http://www.webupd8.org/2017/06/why-oracle-java-7-and-6-installers-no.html
http://www.oracle.com/technetwork/java/javase/downloads/jdk9-downloads-3848520.html