### PR TITLE
use wget to fetch golang tar

### DIFF
--- a/golang-1.10.2.yml
+++ b/golang-1.10.2.yml
@@ -1,0 +1,5 @@
+---
+- hosts: vagrant
+  remote_user: vagrant
+  roles:
+    - { role: golang, golang_version: 1.10.2 }

--- a/roles/golang/tasks/main.yml
+++ b/roles/golang/tasks/main.yml
@@ -12,9 +12,14 @@
   ignore_errors: yes
   register: go_version
 
+- name: Check that the golang tar exists
+  stat:
+    path: "{{ansible_cache_dir}}/{{golang_tarball}}"
+  register: golang_tar
+
 - name: Install | Download the Go tarball
-  get_url: url={{golang_download_location}}
-           dest={{ansible_cache_dir}}
+  command: wget {{golang_download_location}} -P {{ansible_cache_dir}}
+  when: golang_tar.stat.exists == False
   sudo: yes
 
 - name: Install | Extract the Go tarball if Go is not yet installed or if it is not the desired version


### PR DESCRIPTION
The builtin module get_url raises connection reset by peer when downloading the golang tar.

Tested the download using the browser and using wget. The two methods worked ok.

The error that is happening is:

```
default: TASK [golang : Install | Download the Go tarball] ******************************
    default: fatal: [127.0.0.1]: FAILED! => {"changed": false, "failed": true, "msg": "failed to create temporary content file: (104, 'Connection reset by peer')"}
    default: 	to retry, use: --limit @/vagrant/vagrant/oss-playbooks/golang-1.10.2.retry
```

This PR also add support for version 1.10.2 of golang.