### PR TITLE
Add playbook for consul version 1.7.2

### DIFF
--- a/consul-1.7.2.yml
+++ b/consul-1.7.2.yml
@@ -1,0 +1,5 @@
+---
+- hosts: vagrant
+  remote_user: vagrant
+  roles:
+    - { role: consul, consul_version: 1.7.2 }


### PR DESCRIPTION
* Add playbook for consul version 1.7.2
~~* Update the default consul version to 1.7.2~~ left the default as 0.5.2

This is part of updating dependencies in the dataflow-runner repo where the latest testutil package is imported, but a very old consul cli is being installed:

See https://github.com/snowplow/dataflow-runner/issues/36