### PR TITLE
Update wine install to use the new winehq.key

### DIFF
--- a/roles/wine/tasks/main.yml
+++ b/roles/wine/tasks/main.yml
@@ -4,8 +4,8 @@
   sudo: yes
   with_items:
     - "dpkg --add-architecture i386"
-    - "wget -nc https://dl.winehq.org/wine-builds/Release.key"
-    - "apt-key add Release.key"
+    - "wget -nc https://dl.winehq.org/wine-builds/winehq.key"
+    - "apt-key add winehq.key"
     - "apt-add-repository https://dl.winehq.org/wine-builds/ubuntu/"
-    - "apt-get update"
+    - "apt update"
     - "apt-get install -y winehq-stable"


### PR DESCRIPTION
Update wine install to use the new winehq.key
Use apt update instead of apt-get update as recommended in the wine wiki

This is noted on the [WineHQ wiki](https://wiki.winehq.org/Ubuntu):

> The WineHQ repository key was changed on 2018-12-19. If you downloaded and added the key before that time, you will need to download and add the new key and run sudo apt update to accept the repository changes.

This PR is intended to address one of the dataflow-runner dev environment build issues noted in https://github.com/snowplow/dataflow-runner/issues/62